### PR TITLE
fixes class names in devtools

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,12 +84,22 @@ const config = {
         exclude: ['/node_modules/']
       },
       {
-        test: /\.css$/i,
-        use: [isEnvProduction ? MiniCssExtractPlugin.loader : "style-loader", "css-loader"],
-      },
-      {
-        test: /\.s[ac]ss$/i,
-        use: [isEnvProduction ? MiniCssExtractPlugin.loader : 'style-loader', 'css-loader', 'sass-loader']
+        test: /\.s?[ac]ss$/i,
+        use: [
+          isEnvProduction ? MiniCssExtractPlugin.loader : 'style-loader' ,
+          {
+            loader: 'css-loader',
+            options: {
+              modules: {
+                auto: (resPath) => Boolean(resPath.includes('.module.')),
+                localIdentName: isEnvProduction
+                  ? '[hash:base64:8]'
+                  : '[local]--[hash:base64:5]',
+              },
+            },
+          },
+          'sass-loader',
+        ],
       },
       {
         test: /\.(eot|svg|ttf|woff|woff2|png|jpg|jpeg|gif|webp)$/i,


### PR DESCRIPTION
![image](https://github.com/Studio-Yandex-Practicum/maxboom_frontend/assets/54811697/fd560e3b-bbe2-40dc-838d-16a537a54b8a)
исправляет имя класса в виде хэша на имя класса + хэш