### PR TITLE
#215-render-categories-from-api

### DIFF
--- a/src/app/providers/StoreProvider/config/StateSchema.ts
+++ b/src/app/providers/StoreProvider/config/StateSchema.ts
@@ -1,4 +1,4 @@
-import { CategorySchema } from '@/entities/Category/types/types'
+import { CategoryId, CategorySlug, CategorySchema } from '@/entities/Category/types/types'
 import { SearchResultSchema } from '@/features/SearchProduct/types/types'
 import { LoginSchema } from '@/features/login/model/types/types'
 import { BrandSchema } from '@/widgets/BrandBlock/types/types'
@@ -11,7 +11,8 @@ import { IStoriesSchema } from '@/widgets/StoriesBlock/model/types/types'
 import { CoreBaseHeaderSchema } from '@/widgets/Header/model/types/types'
 import { TProductSchema } from '@/pages/ProductPage/model/types/productTypes'
 import { CategoryListSchema } from '@/widgets/CategoryGrid/model/types/types'
-import { ICategoryProductsSchema, ProductsData } from '@/pages/ProductsPage/types/types'
+import { ICategoryProductsSchema } from '@/pages/ProductsPage/types/types'
+import { CategoryInfo, ICategorySchema, IMainCategorySchema } from '@/widgets/CategoryList/types/types'
 
 export interface StateSchema {
   login: LoginSchema
@@ -27,6 +28,10 @@ export interface StateSchema {
   blogPosts: IBlogPostsSchema
   product: TProductSchema
   categoryProduct: ICategoryProductsSchema
+  categoryId: CategoryId
+  categorySlug: CategorySlug
+  categoryBranches: ICategorySchema
+  getCategories: IMainCategorySchema
 }
 
 export interface ThunkExtraArg {

--- a/src/app/providers/StoreProvider/config/store.ts
+++ b/src/app/providers/StoreProvider/config/store.ts
@@ -14,6 +14,10 @@ import { StateSchema, ThunkExtraArg } from './StateSchema'
 import { productSliceReducer } from '@/pages/ProductPage/model/slice/productSlice'
 import categoryGridSlice from '@/widgets/CategoryGrid/model/slice/categoryGridSlice'
 import { categoriesProductsReducer } from '@/pages/ProductsPage/slice/productsOfCategorySlice'
+import { categoryIdSliceReducer } from '@/entities/Category/slice/categoryIdSlice'
+import { categorySlugSliceReducer } from '@/entities/Category/slice/categorySlugSlice'
+import { categoryBranchesReducer } from '@/widgets/CategoryList/slice/pageCategoryBranchesSlice'
+import { getCategoriesReducer } from '@/widgets/CategoryList/slice/pageCategoriesSlice'
 
 export type RootState = StateSchema
 
@@ -30,7 +34,11 @@ const rootReducer: ReducersMapObject<RootState> = {
   blogPosts: blogPostsReducer,
   product: productSliceReducer,
   categoryProduct: categoriesProductsReducer,
-  categoryList: categoryGridSlice
+  categoryList: categoryGridSlice,
+  categoryId: categoryIdSliceReducer,
+  categorySlug: categorySlugSliceReducer,
+  categoryBranches: categoryBranchesReducer,
+  getCategories: getCategoriesReducer
 }
 
 export function createReduxStore(initialState: RootState) {

--- a/src/components/PageDescription/PageDescription.tsx
+++ b/src/components/PageDescription/PageDescription.tsx
@@ -1,28 +1,42 @@
+import { FC } from 'react'
+
+import { getNoun } from '@/shared/libs/helpers/getNoun'
 import Heading from '@/shared/ui/Heading/Heading'
 import Link from '@/shared/ui/Link/Link'
 import Subheading from '@/shared/ui/Subheading/Subheading'
 
 import styles from './PageDescription.module.scss'
 
+type Props = {
+  count: number
+  heading: string
+}
 /**
  * Компонент заголовка страницы товаров.
  * Содержит информацию о текущей просматриваемой категории.
  * Содержит "хлебные крошки" со ссылкой на главную страницу.
+ * @param {number} count - количество товаров в категории;
+ * @param {string} heading - наименование-заголовок;
  */
-
-export const PageDescription = () => {
+export const PageDescription: FC<Props> = ({ count, heading }) => {
   return (
     <div className={styles.content__description}>
       <div>
-        <Heading className={styles.content__title}>GPS-трекеры</Heading>{' '}
-        <span className={styles['content__items-count']}>1 товар</span>
+        <Heading className={styles.content__title}>{heading}</Heading>{' '}
+        {count >= 0 ? (
+          <span className={styles['content__items-count']}>
+            {count} {getNoun(count, 'товар', 'товара', 'товаров')}
+          </span>
+        ) : (
+          ''
+        )}
       </div>
       <div className={styles.content__breadcrumbs}>
         <Subheading>
           <Link to="/" className={styles.content__link}>
             Главная
           </Link>{' '}
-          / GPS-трекеры
+          / {heading}
         </Subheading>
       </div>
     </div>

--- a/src/entities/Category/selectors/categorySelectors.ts
+++ b/src/entities/Category/selectors/categorySelectors.ts
@@ -2,3 +2,7 @@ import { RootState } from '@/app/providers/StoreProvider/config/store'
 
 export const selectCategories = (state: RootState) => state.category.categories
 export const selectDisplayedCategories = (state: RootState) => state.category.displayedCategories
+
+export const selectCategoryId = (state: RootState) => state.categoryId.categoryId
+
+export const selectCategorySlug = (state: RootState) => state.categorySlug.categorySlug

--- a/src/entities/Category/slice/categoryIdSlice.ts
+++ b/src/entities/Category/slice/categoryIdSlice.ts
@@ -1,0 +1,21 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+import { CategoryId } from '../types/types'
+
+const initialState: CategoryId = {
+  categoryId: 0
+}
+
+const categoryIdSlice = createSlice({
+  name: 'categoryId',
+  initialState,
+  reducers: {
+    setCategoryId(state, action) {
+      state.categoryId = action.payload
+    }
+  }
+})
+
+export const { reducer: categoryIdSliceReducer } = categoryIdSlice
+
+export const { setCategoryId } = categoryIdSlice.actions

--- a/src/entities/Category/slice/categorySlugSlice.ts
+++ b/src/entities/Category/slice/categorySlugSlice.ts
@@ -1,0 +1,21 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+import { CategorySlug } from '../types/types'
+
+const initialState: CategorySlug = {
+  categorySlug: ''
+}
+
+const categorySlugSlice = createSlice({
+  name: 'categorySlug',
+  initialState,
+  reducers: {
+    setCategorySlug(state, action) {
+      state.categorySlug = action.payload
+    }
+  }
+})
+
+export const { reducer: categorySlugSliceReducer } = categorySlugSlice
+
+export const { setCategorySlug } = categorySlugSlice.actions

--- a/src/entities/Category/types/types.ts
+++ b/src/entities/Category/types/types.ts
@@ -15,3 +15,11 @@ export interface Category {
   image?: string
   type?: 'category'
 }
+
+export interface CategoryId {
+  categoryId: number
+}
+
+export interface CategorySlug {
+  categorySlug: string
+}

--- a/src/features/CategoryItem/CategoryItem.stories.tsx
+++ b/src/features/CategoryItem/CategoryItem.stories.tsx
@@ -1,23 +1,20 @@
 import { Meta, StoryObj } from '@storybook/react'
-import { FC } from 'react'
 
 import { CategoryItem } from '@/features/CategoryItem/CategoryItem'
 
-const StorybookWrapper: FC = () => {
-  return (
-    <div>
-      <CategoryItem />
-    </div>
-  )
-}
-
 const meta = {
   title: 'features/CategoryItem',
-  component: StorybookWrapper,
+  component: CategoryItem,
   tags: ['autodocs']
-} satisfies Meta<typeof StorybookWrapper>
+} satisfies Meta<typeof CategoryItem>
 
 export default meta
 type Story = StoryObj<typeof meta>
-
-export const Default: Story = {}
+export const Default: Story = {
+  args: {
+    name: 'Тестовое имя категории',
+    slug: '/test',
+    count: 999,
+    id: 999
+  }
+}

--- a/src/features/CategoryItem/CategoryItem.tsx
+++ b/src/features/CategoryItem/CategoryItem.tsx
@@ -1,13 +1,38 @@
 import { FC } from 'react'
+import { useDispatch } from 'react-redux'
 
+import { setCategoryId } from '@/entities/Category/slice/categoryIdSlice'
+import { setCategorySlug } from '@/entities/Category/slice/categorySlugSlice'
 import styles from '@/features/CategoryItem/CategoryItem.module.scss'
+import { Routes } from '@/shared/config/routerConfig/routes'
 import Link from '@/shared/ui/Link/Link'
 
-export const CategoryItem: FC = () => {
+type Props = {
+  name: string
+  slug: string
+  count: number
+  id: number
+}
+
+/**
+ * Компонент единицы категории в списке категорий бокового меню
+ * @param {string} name - название категории;
+ * @param {string} slug - URL для страницы категориии;
+ * @param {number} count - количество товаров в категории;
+ * @param {number} id - id категории;
+ */
+export const CategoryItem: FC<Props> = ({ name, slug, count, id }) => {
+  const dispatch = useDispatch()
   return (
     <li className={styles['category-list__item']}>
-      <Link to="#" className={styles['category-list__link']}>
-        SSD-накопители (1)
+      <Link
+        to={`${Routes.CATEGORIES}/${slug}`}
+        className={styles['category-list__link']}
+        onClick={() => {
+          dispatch(setCategoryId(id))
+          dispatch(setCategorySlug(slug))
+        }}>
+        {name} ({count})
       </Link>
     </li>
   )

--- a/src/features/ProductImgCarousel/ui/PreviewCarousel/PreviewCarousel.tsx
+++ b/src/features/ProductImgCarousel/ui/PreviewCarousel/PreviewCarousel.tsx
@@ -35,6 +35,7 @@ export const PreviewCarousel: FC<TPreviewCarouselProps> = ({ imgList, curImg, se
 
   const changeImg = (direction: TchangeImgArgs, curIndex: number = 0) => {
     if (imgList.length) {
+      console.log(imgList)
       let index: number = 0
       switch (direction) {
         case 'next':

--- a/src/pages/ProductPage/ProductPage.tsx
+++ b/src/pages/ProductPage/ProductPage.tsx
@@ -30,7 +30,8 @@ export const ProductPage = () => {
   return (
     <>
       <WrapperForMainContent>
-        <PageDescription />
+        {/*Добавила пропс count, чтобы не было ошибки, нужно его вытащить из апи*/}
+        <PageDescription count={-1} heading={productStore.product.name} />
         <Product product={productStore.product} />
         <ProductInfo description={productStore.product.description} />
         <Advantages />

--- a/src/pages/ProductsPage/ProductsPage.tsx
+++ b/src/pages/ProductsPage/ProductsPage.tsx
@@ -5,7 +5,10 @@ import { PageControls } from '@/components/PageControls/PageControls'
 import { PageDescription } from '@/components/PageDescription/PageDescription'
 import { Pagination } from '@/components/Pagination/Pagination'
 import WrapperForMainContent from '@/components/WrapperForMainContent/WrapperForMainContent'
+import { selectCategoryId } from '@/entities/Category/selectors/categorySelectors'
+import { selectCategorySlug } from '@/entities/Category/selectors/categorySelectors'
 import { ITEMS_PER_PAGE_OPTION, SORT_OPTION, TOTAL_PAGES } from '@/mockData/productsPageOptions'
+import { IObjectWithImage } from '@/pages/ProductPage/model/types/productTypes'
 import { getProductsOfCategorySelector } from '@/pages/ProductsPage/selectors/selectors'
 import { getProducts } from '@/pages/ProductsPage/services/getProducts'
 import { useAppDispatch } from '@/shared/libs/hooks/store'
@@ -58,43 +61,56 @@ export const ProductsPage = () => {
 
   const dispatch = useAppDispatch()
   const categoriesProducts = useSelector(getProductsOfCategorySelector)
+  const categoryId = useSelector(selectCategoryId)
+  const categorySlug = useSelector(selectCategorySlug)
 
   useEffect(() => {
-    dispatch(getProducts())
-  }, [])
+    dispatch(getProducts(categoryId))
+  }, [categoryId, categorySlug])
 
   return (
     <>
       <WrapperForMainContent>
-        <PageDescription />
+        <PageDescription count={categoriesProducts.count} heading={categoriesProducts.category_name} />
         <div className={styles['content-grid']}>
           <CategoryList />
           <div className={styles['content-main']}>
-            <PageControls
-              cardView={cardView}
-              handleCardViewChange={handleCardViewChange}
-              handleItemsPerPageChange={handleItemsPerPageChange}
-              handleSortChange={handleSortChange}
-              itemPerPageOptions={ITEMS_PER_PAGE_OPTION}
-              sortOptions={SORT_OPTION}
-            />
             <section className={styles['content-products']}>
-              {categoriesProducts.results.map(item => (
-                <ProductItem
-                  key={item.id}
-                  layout={cardView}
-                  name={item.name}
-                  price={item.price}
-                  brand={item.brand}
-                  slug={item.slug}
-                  description={item.description}
-                  code={item.code}
-                  images={item.images}
-                  label_hit={item.label_hit}
-                  label_popular={item.label_popular}
-                  quantity={item.quantity}
-                />
-              ))}
+              {categoriesProducts.results.length > 0 ? (
+                <>
+                  <PageControls
+                    cardView={cardView}
+                    handleCardViewChange={handleCardViewChange}
+                    handleItemsPerPageChange={handleItemsPerPageChange}
+                    handleSortChange={handleSortChange}
+                    itemPerPageOptions={ITEMS_PER_PAGE_OPTION}
+                    sortOptions={SORT_OPTION}
+                  />
+                  {categoriesProducts.results.map(item => (
+                    <ProductItem
+                      key={item.id}
+                      layout={cardView}
+                      name={item.name}
+                      price={item.price}
+                      brand={item.brand}
+                      slug={item.slug}
+                      description={item.description}
+                      code={item.code}
+                      images={item.images.map((img: IObjectWithImage, index: number) => {
+                        return {
+                          image: img.image,
+                          index
+                        }
+                      })}
+                      label_hit={item.label_hit}
+                      label_popular={item.label_popular}
+                      quantity={item.quantity}
+                    />
+                  ))}
+                </>
+              ) : (
+                'В данной категории нет товаров'
+              )}
             </section>
             <Pagination
               currentPage={currentPage}

--- a/src/pages/ProductsPage/slice/productsOfCategorySlice.ts
+++ b/src/pages/ProductsPage/slice/productsOfCategorySlice.ts
@@ -9,6 +9,7 @@ import { ICategoryProductsSchema } from '../types/types'
 const initialState: ICategoryProductsSchema = {
   isLoading: false,
   productsData: {
+    category_name: '',
     count: 0,
     next: '',
     previous: '',

--- a/src/pages/ProductsPage/types/types.ts
+++ b/src/pages/ProductsPage/types/types.ts
@@ -17,6 +17,7 @@ export interface ProductsData {
 }
 
 export interface ProductsInfo {
+  category_name: string
   count: number
   next: string
   previous: string

--- a/src/shared/constants/constants.ts
+++ b/src/shared/constants/constants.ts
@@ -35,9 +35,14 @@ export const ACTION_GET_SHOP_NEWS = 'get-shop-news'
 export const ACTION_GET_BLOG_POSTS = 'get-blog-posts'
 
 export const ACTION_GET_PRODUCTS_OF_CATEGORY = 'get-products-of-category'
+export const ACTION_GET_CATEGORY_BRANCHES = 'get-category-branches'
+export const ACTION_GET_CATEGORIES = 'get-categories'
 
 // Reducers
 export const REDUCER_SHOP_NEWS = 'shopNews'
 export const REDUCER_BLOG_POSTS = 'shopBlogPosts'
 
 export const REDUCER_CATEGORIES_PRODUCTS = 'shopCategoriesProducts'
+
+export const REDUCER_CATEGORY_BRANCHES = 'getCategoryBranches'
+export const REDUCER_CATEGORIES = 'getCategories'

--- a/src/shared/libs/helpers/getNoun.ts
+++ b/src/shared/libs/helpers/getNoun.ts
@@ -1,0 +1,22 @@
+/**
+ * Функция изменения окончания слова, в зависимости от значения числа
+ * @param {number} number - число, от которого зависит окончание;
+ * @param {string} var1 - вариант текста;
+ * @param {string} var2 - вариант текста;
+ * @param {string} var3 - вариант текста;
+ */
+export const getNoun = (number: number, var1?: string, var2?: string, var3?: string) => {
+  let n = Math.abs(number)
+  n %= 100
+  if (n >= 5 && n <= 20) {
+    return var3
+  }
+  n %= 10
+  if (n === 1) {
+    return var1
+  }
+  if (n >= 2 && n <= 4) {
+    return var2
+  }
+  return var3
+}

--- a/src/shared/libs/helpers/handleCutDescription.ts
+++ b/src/shared/libs/helpers/handleCutDescription.ts
@@ -2,7 +2,6 @@
  * Функция ограничения текста описания до 175 символов
  * @param {string} description - текст-описание;
  */
-
 export const handleCutDescription = (description: string) => {
   let sliced: string = description.slice(0, 175)
   if (sliced.length < description.length) {

--- a/src/shared/ui/CatalogLink/CatalogLink.tsx
+++ b/src/shared/ui/CatalogLink/CatalogLink.tsx
@@ -1,6 +1,10 @@
 import classNames from 'classnames'
 import { FC } from 'react'
+import { useDispatch } from 'react-redux'
 
+import { AppDispatch } from '@/app/providers/StoreProvider/config/store'
+import { setCategoryId } from '@/entities/Category/slice/categoryIdSlice'
+import { setCategorySlug } from '@/entities/Category/slice/categorySlugSlice'
 import Link, { TLinkProps } from '@/shared/ui/Link/Link'
 
 import styles from './catalogLink.module.scss'
@@ -9,12 +13,20 @@ import styles from './catalogLink.module.scss'
  * @param {string} className - нужно для изменения некоторых css- параметров
  * @param to - путь для ссылки
  * @param children дочерние компоненты
+ * @param {string} categoryId - id категории
  */
-const CatalogLink: FC<TLinkProps> = ({ className, to = '', children }) => {
+const CatalogLink: FC<TLinkProps> = ({ className, to = '', children, categoryId }) => {
   const classes = classNames(styles['catalog-link'], className)
+  const dispatch = useDispatch<AppDispatch>()
 
   return (
-    <Link to={to} className={classes}>
+    <Link
+      to={to}
+      className={classes}
+      onClick={() => {
+        dispatch(setCategoryId(categoryId))
+        dispatch(setCategorySlug(to))
+      }}>
       {children}
     </Link>
   )

--- a/src/shared/ui/Link/Link.tsx
+++ b/src/shared/ui/Link/Link.tsx
@@ -6,6 +6,7 @@ import styles from './Link.module.scss'
 
 export type TLinkProps = {
   className?: string
+  categoryId?: number
 } & LinkProps
 
 /**

--- a/src/widgets/CatalogNodeItem/CatalogNodeItem.tsx
+++ b/src/widgets/CatalogNodeItem/CatalogNodeItem.tsx
@@ -1,15 +1,37 @@
+import { FC } from 'react'
+import { useDispatch } from 'react-redux'
+
+import { AppDispatch } from '@/app/providers/StoreProvider/config/store'
+import { setCategoryId } from '@/entities/Category/slice/categoryIdSlice'
+import { setCategorySlug } from '@/entities/Category/slice/categorySlugSlice'
 import { Category } from '@/entities/Category/types/types'
 import { Routes } from '@/shared/config/routerConfig/routes'
 import Link from '@/shared/ui/Link/Link'
 
 import styles from './CatalogNodeItem.module.scss'
 
+type Props = {
+  slug: string
+  name: string
+  id: number | undefined
+}
+
 /**
  * Компонент ссылки на раздел каталога для выпадающего списка меню "Все категории"
+ * @param {string} slug - URL для страницы категории;
+ * @param {string} name - название категории;
+ * @param {number} id - id категории;
  */
-const CatalogNodeItem = ({ slug, name }: Category) => {
+const CatalogNodeItem: FC<Props> = ({ slug, name, id }: Category) => {
+  const dispatch = useDispatch<AppDispatch>()
+
   return (
-    <li className={styles.li}>
+    <li
+      className={styles.li}
+      onClick={() => {
+        dispatch(setCategoryId(id))
+        dispatch(setCategorySlug(slug))
+      }}>
       <Link to={`${Routes.CATEGORIES}/${slug}`} className={styles.link}>
         {name}
       </Link>

--- a/src/widgets/CategoryList/CategoryList.tsx
+++ b/src/widgets/CategoryList/CategoryList.tsx
@@ -1,7 +1,13 @@
-import { FC } from 'react'
+import { FC, useEffect } from 'react'
+import { useSelector } from 'react-redux'
 
+import { selectCategorySlug } from '@/entities/Category/selectors/categorySelectors'
 import { CategoryItem } from '@/features/CategoryItem/CategoryItem'
+import { useAppDispatch } from '@/shared/libs/hooks/store'
 import Heading, { HeadingType } from '@/shared/ui/Heading/Heading'
+import { getCategoryBranchesSelector, getCategorySelector } from '@/widgets/CategoryList/selectors/selectors'
+import { getCategoryBranches } from '@/widgets/CategoryList/services/getCategoryBranches'
+import { getCategories } from '@/widgets/CategoryList/services/getCatergories'
 
 import styles from './CategoryList.module.scss'
 
@@ -10,15 +16,42 @@ import styles from './CategoryList.module.scss'
  * Фиксированная высота настраивается классом .category-list__items
  */
 export const CategoryList: FC = () => {
+  const dispatch = useAppDispatch()
+  const categoryBranches = useSelector(getCategoryBranchesSelector)
+  const getMainCategories = useSelector(getCategorySelector)
+  const categorySlug = useSelector(selectCategorySlug)
+
+  useEffect(() => {
+    dispatch(getCategoryBranches(categorySlug))
+    dispatch(getCategories())
+  }, [categorySlug])
+
   return (
     <div className={styles['category-list']}>
       <Heading type={HeadingType.NORMAL} className={styles['category-list__title']}>
         Категории
       </Heading>
       <ul className={styles['category-list__items']}>
-        {Array.from({ length: 10 }, (_, index) => (
-          <CategoryItem key={index} />
-        ))}
+        {categoryBranches.branches?.length > 0
+          ? categoryBranches.branches.map(item => (
+              <CategoryItem
+                key={item.id}
+                id={item.id}
+                name={item.name}
+                slug={item.slug}
+                count={item.products_count}
+              />
+            ))
+          : getMainCategories.map(item => (
+              <CategoryItem
+                key={item.id}
+                id={item.id}
+                name={item.name}
+                slug={item.slug}
+                // Поля count в списке категорий верхнего уровня на бэке нет, если мы его оставляем, то нужно будет запросить вывод количества товаров
+                count={0}
+              />
+            ))}
       </ul>
     </div>
   )

--- a/src/widgets/CategoryList/selectors/selectors.ts
+++ b/src/widgets/CategoryList/selectors/selectors.ts
@@ -1,0 +1,9 @@
+import { StateSchema } from '@/app/providers/StoreProvider'
+
+export const getCategoryBranchesSelector = (state: StateSchema) => {
+  return state.categoryBranches.categoryInfo
+}
+
+export const getCategorySelector = (state: StateSchema) => {
+  return state.getCategories.mainCategoriesInfo
+}

--- a/src/widgets/CategoryList/services/getCategoryBranches.ts
+++ b/src/widgets/CategoryList/services/getCategoryBranches.ts
@@ -3,16 +3,15 @@ import { createAsyncThunk } from '@reduxjs/toolkit'
 import { ThunkConfig } from '@/app/providers/StoreProvider/config/StateSchema'
 import { apiErrorIdentify } from '@/shared/api/apiErrorIdentify'
 import { ApiError, ApiErrorTypes, ApiRoutes } from '@/shared/api/types'
-import { ACTION_GET_PRODUCTS_OF_CATEGORY } from '@/shared/constants/constants'
+import { ACTION_GET_CATEGORY_BRANCHES } from '@/shared/constants/constants'
+import { CategoryInfo } from '@/widgets/CategoryList/types/types'
 
-import { ProductsInfo } from '../types/types'
-
-export const getProducts = createAsyncThunk<ProductsInfo, number, ThunkConfig<ApiError>>(
-  ACTION_GET_PRODUCTS_OF_CATEGORY,
-  async (id: number, thunkAPI) => {
+export const getCategoryBranches = createAsyncThunk<CategoryInfo, string | undefined, ThunkConfig<ApiError>>(
+  ACTION_GET_CATEGORY_BRANCHES,
+  async (slug, thunkAPI) => {
     const { rejectWithValue, extra } = thunkAPI
     try {
-      const { data } = await extra.api.get(`api/${ApiRoutes.PRODUCT}${id > 0 ? `?category=${id}` : ''}`)
+      const { data } = await extra.api.get(`api/${ApiRoutes.CATEGORIES}/${slug}?category_tree=true`)
       return data
     } catch (error) {
       return rejectWithValue(apiErrorIdentify(error, ApiErrorTypes.DATA_EMPTY_ERROR))

--- a/src/widgets/CategoryList/services/getCatergories.ts
+++ b/src/widgets/CategoryList/services/getCatergories.ts
@@ -3,16 +3,15 @@ import { createAsyncThunk } from '@reduxjs/toolkit'
 import { ThunkConfig } from '@/app/providers/StoreProvider/config/StateSchema'
 import { apiErrorIdentify } from '@/shared/api/apiErrorIdentify'
 import { ApiError, ApiErrorTypes, ApiRoutes } from '@/shared/api/types'
-import { ACTION_GET_PRODUCTS_OF_CATEGORY } from '@/shared/constants/constants'
+import { ACTION_GET_CATEGORIES } from '@/shared/constants/constants'
+import { MainCategoryInfo } from '@/widgets/CategoryList/types/types'
 
-import { ProductsInfo } from '../types/types'
-
-export const getProducts = createAsyncThunk<ProductsInfo, number, ThunkConfig<ApiError>>(
-  ACTION_GET_PRODUCTS_OF_CATEGORY,
-  async (id: number, thunkAPI) => {
+export const getCategories = createAsyncThunk<MainCategoryInfo[], void, ThunkConfig<ApiError>>(
+  ACTION_GET_CATEGORIES,
+  async (_, thunkAPI) => {
     const { rejectWithValue, extra } = thunkAPI
     try {
-      const { data } = await extra.api.get(`api/${ApiRoutes.PRODUCT}${id > 0 ? `?category=${id}` : ''}`)
+      const { data } = await extra.api.get(`api/${ApiRoutes.CATEGORIES}?category_tree=true`)
       return data
     } catch (error) {
       return rejectWithValue(apiErrorIdentify(error, ApiErrorTypes.DATA_EMPTY_ERROR))

--- a/src/widgets/CategoryList/slice/pageCategoriesSlice.ts
+++ b/src/widgets/CategoryList/slice/pageCategoriesSlice.ts
@@ -1,0 +1,36 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+import { rejectedPayloadHandle } from '@/shared/api/rejectedPayloadHandle'
+import { REDUCER_CATEGORIES } from '@/shared/constants/constants'
+import { getCategories } from '@/widgets/CategoryList/services/getCatergories'
+import { IMainCategorySchema } from '@/widgets/CategoryList/types/types'
+
+const initialState: IMainCategorySchema = {
+  isLoading: false,
+  mainCategoriesInfo: []
+}
+
+export const getCategoriesSlice = createSlice({
+  name: REDUCER_CATEGORIES,
+  initialState,
+  reducers: {
+    errorReset: state => {
+      state.error = undefined
+    }
+  },
+  extraReducers: builder => {
+    builder
+      .addCase(getCategories.pending, state => {
+        state.isLoading = true
+      })
+      .addCase(getCategories.fulfilled, (state, { payload }) => {
+        state.isLoading = false
+        state.mainCategoriesInfo = payload
+      })
+      .addCase(getCategories.rejected, (state, { payload }) => {
+        state.isLoading = false
+        state.error = rejectedPayloadHandle(payload)
+      })
+  }
+})
+export const { actions: getCategoriesActions, reducer: getCategoriesReducer } = getCategoriesSlice

--- a/src/widgets/CategoryList/slice/pageCategoryBranchesSlice.ts
+++ b/src/widgets/CategoryList/slice/pageCategoryBranchesSlice.ts
@@ -1,0 +1,45 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+import { rejectedPayloadHandle } from '@/shared/api/rejectedPayloadHandle'
+import { REDUCER_CATEGORY_BRANCHES } from '@/shared/constants/constants'
+import { getCategoryBranches } from '@/widgets/CategoryList/services/getCategoryBranches'
+import { ICategorySchema } from '@/widgets/CategoryList/types/types'
+
+const initialState: ICategorySchema = {
+  isLoading: false,
+  categoryInfo: {
+    id: 0,
+    name: '',
+    slug: '',
+    branches: [],
+    root: null,
+    is_prohibited: false,
+    is_visible_on_main: false,
+    image: null
+  }
+}
+
+export const categoryBranchesSlice = createSlice({
+  name: REDUCER_CATEGORY_BRANCHES,
+  initialState,
+  reducers: {
+    errorReset: state => {
+      state.error = undefined
+    }
+  },
+  extraReducers: builder => {
+    builder
+      .addCase(getCategoryBranches.pending, state => {
+        state.isLoading = true
+      })
+      .addCase(getCategoryBranches.fulfilled, (state, { payload }) => {
+        state.isLoading = false
+        state.categoryInfo = payload
+      })
+      .addCase(getCategoryBranches.rejected, (state, { payload }) => {
+        state.isLoading = false
+        state.error = rejectedPayloadHandle(payload)
+      })
+  }
+})
+export const { actions: categoryBranchesActions, reducer: categoryBranchesReducer } = categoryBranchesSlice

--- a/src/widgets/CategoryList/types/types.ts
+++ b/src/widgets/CategoryList/types/types.ts
@@ -1,0 +1,41 @@
+export interface ICategorySchema {
+  isLoading: boolean
+  categoryInfo: CategoryInfo
+  error?: string | string[]
+}
+
+export interface CategoryInfo {
+  id: number
+  name: string
+  slug: string
+  branches: BranchesData[]
+  root: boolean | null
+  is_prohibited: boolean
+  is_visible_on_main: boolean
+  image?: [] | null
+}
+
+export interface BranchesData {
+  id: number
+  name: string
+  slug: string
+  products_count: number
+  branches: BranchesData[]
+}
+
+export interface IMainCategorySchema {
+  isLoading: boolean
+  mainCategoriesInfo: MainCategoryInfo[]
+  error?: string | string[]
+}
+
+export interface MainCategoryInfo {
+  id: number
+  name: string
+  slug: string
+  branches: BranchesData[]
+  root: boolean | null
+  is_prohibited: boolean
+  is_visible_on_main: boolean
+  image?: [] | null
+}

--- a/src/widgets/Header/Header.tsx
+++ b/src/widgets/Header/Header.tsx
@@ -92,7 +92,7 @@ function Header() {
     () => (
       <ul className={styles['header__context-menu-list']}>
         {categories.map(category => (
-          <CatalogNodeItem key={category.id} slug={category.slug} name={category.name} />
+          <CatalogNodeItem key={category.id} slug={category.slug} name={category.name} id={category.id} />
         ))}
       </ul>
     ),
@@ -170,7 +170,10 @@ function Header() {
 
             <div className={styles['header__tags']}>
               {displayedCategories.map(category => (
-                <CatalogLink key={category.id} to={`${Routes.CATEGORIES}/${category.slug}`}>
+                <CatalogLink
+                  key={category.id}
+                  to={`${Routes.CATEGORIES}/${category.slug}`}
+                  categoryId={category.id}>
                   {category.name}
                 </CatalogLink>
               ))}

--- a/src/widgets/ProductItem/CardPreview/CardPreview.module.scss
+++ b/src/widgets/ProductItem/CardPreview/CardPreview.module.scss
@@ -2,9 +2,8 @@
 
 .modal-card {
   margin: 0 50px;
-  padding: 20px;
   display: flex;
-  align-items: center;
+  align-items: normal;
   gap: 18px;
   background-color: var.$white;
   border-radius: 10px;
@@ -20,7 +19,7 @@
 }
 
 .description {
-  padding: 0 20px;
+  padding: 20px;
   flex-grow: 1;
   border-left: 1px solid var.$border-color;
 }

--- a/src/widgets/ProductItem/CardPreview/CardPreview.tsx
+++ b/src/widgets/ProductItem/CardPreview/CardPreview.tsx
@@ -4,12 +4,14 @@ import { useNavigate } from 'react-router-dom'
 import { CardPreviewFooter } from '@/features/CardPreviewFooter/CardPreviewFooter'
 import { CardPreviewHeader } from '@/features/CardPreviewHeader/CardPreviewHeader'
 import { ProductAvailability } from '@/features/ProductAvailability/ProductAvailability'
+import { ProductImgCarousel } from '@/features/ProductImgCarousel/ProductImgCarousel'
 import { TImgList } from '@/pages/ProductsPage/types/types'
 import { Routes } from '@/shared/config/routerConfig/routes'
 import { Button, ButtonSize, ButtonTheme } from '@/shared/ui/Button/Button'
 import Modal from '@/shared/ui/Modal/Modal'
 import Paragraph from '@/shared/ui/Paragraph/Paragraph'
 import Spinner from '@/shared/ui/Spinner/Spinner'
+import { PopupImg } from '@/widgets/Product/ui/PopupImg/PopupImg'
 
 import styles from './CardPreview.module.scss'
 
@@ -17,30 +19,30 @@ const LazyQuickPurchaseForm = lazy(() => import('@/features/QuickPurchase/index'
 
 type Props = {
   code: number
-  name: string
   price: number
   brand: string
   slug: string
   images: TImgList
   quantity: number
 }
+
 /**
  * Компонент с контентом поп-апа предварительного просмотра товара.
  * @param {number} code - артикул товара;
- * @param {string} name - название;
  * @param {number} price - цена;
  * @param {string} brand - производитель;
  * @param {string} slug - URL для страницы товара;
  * @param {TImgList} images - массив с изображениями;
  * @param {number} quantity - количество на склаладе (если  > 0, то товар считается в наличии);
  */
-
-export const CardPreview: FC<Props> = ({ code, images, name, slug, brand, quantity, price }) => {
+export const CardPreview: FC<Props> = ({ code, images, slug, brand, quantity, price }) => {
   const [isInCart, setIsInCart] = useState<boolean>(false)
   const [isLiked, setIsLiked] = useState<boolean>(false)
   const [isInCompared, setIsInCompared] = useState<boolean>(false)
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [isModalClosing, setIsModalClosing] = useState(false)
+
+  const [showPopup, setShowPopup] = useState<boolean>(false)
 
   const handleAddToCart = () => {
     setIsInCart(!isInCart)
@@ -81,9 +83,11 @@ export const CardPreview: FC<Props> = ({ code, images, name, slug, brand, quanti
         </Modal>
       )}
       <section className={styles['modal-card']}>
-        {/* @TODO: Добавить компонент для фотографии товара
-      https://github.com/Studio-Yandex-Practicum/maxboom_frontend/issues/41 */}
-        <img src={`${images[0].image}`} alt={name} className={styles['modal-card__image']} />
+        <ProductImgCarousel imgList={images} setShowPopup={setShowPopup} />
+        {showPopup && <PopupImg imgList={images} setShowPopup={setShowPopup} />}
+        {/*  /!* @TODO: Добавить компонент для фотографии товара*/}
+        {/*https://github.com/Studio-Yandex-Practicum/maxboom_frontend/issues/41 *!/*/}
+        {/*  <img src={`${images[0].image}`} alt={name} className={styles['modal-card__image']} />*/}
         <div className={styles.description}>
           <CardPreviewHeader
             brand={brand}

--- a/src/widgets/ProductItem/CardPreview/CardPrewiew.stories.tsx
+++ b/src/widgets/ProductItem/CardPreview/CardPrewiew.stories.tsx
@@ -16,7 +16,6 @@ export const Default: Story = {
   args: {
     code: 999,
     images: [{ image: image1 }],
-    name: 'Тестовое имя товара',
     slug: '/test',
     quantity: 999,
     brand: 'MaxBoom',

--- a/src/widgets/ProductItem/ProductItem.tsx
+++ b/src/widgets/ProductItem/ProductItem.tsx
@@ -92,7 +92,6 @@ export const ProductItem: FC<TProductCard> = ({
           setIsModalClosing={setIsModalClosing}>
           <CardPreview
             code={code}
-            name={name}
             price={price}
             brand={brand}
             slug={slug}


### PR DESCRIPTION
- Подключен вывод подкатегорий с количеством товаров и категорий верхнего уровня из API;
- Сделан вывод названия категории и количества товаров категории, на странице которой находишься;
- Добавлен проброс slug и id категории в хедер и в боковое меню категории;
- Добавлена карусель в превью товара + немного отредактирован css;