### PR TITLE
enhancement_362_overview_widget

### DIFF
--- a/src/entities/OverviewBox/index.tsx
+++ b/src/entities/OverviewBox/index.tsx
@@ -1,0 +1,2 @@
+import OverviewBox from './ui/OverviewBox'
+export default OverviewBox

--- a/src/entities/OverviewBox/ui/OverviewBox.module.scss
+++ b/src/entities/OverviewBox/ui/OverviewBox.module.scss
@@ -1,0 +1,41 @@
+@use '@/shared/styles/utils/variables' as var;
+
+.overviewBox {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  background: var.$white;
+  border-radius: 10px;
+  padding: 30px 30px 20px;
+
+  &__title {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  &__pageRoute {
+    opacity: 1;
+    transition: 0.25s;
+
+    &:hover {
+      opacity: 0.7;
+    }
+  }
+
+  &__subtitle {
+    font-size: 16px;
+  }
+
+  &__itemRouteText {
+    font-size: 15px;
+    border-top: 1px solid var.$border-color;
+    padding-top: 15px;
+    opacity: 1;
+    transition: 0.25s;
+
+    &:hover {
+      opacity: 0.7;
+    }
+  }
+}

--- a/src/entities/OverviewBox/ui/OverviewBox.stories.tsx
+++ b/src/entities/OverviewBox/ui/OverviewBox.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import OverviewBox from './OverviewBox'
+
+const meta = {
+  title: 'entities/OverviewBox',
+  component: OverviewBox,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs']
+} satisfies Meta<typeof OverviewBox>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = () => {
+  const title = 'Заголовок карточки'
+  const pageRoute = '#'
+  const pageRouteText = 'Весь список'
+  const subtitle = 'Вы ничего не покупали!'
+  const itemRoute = '#'
+  const itemRouteText = 'смотрим конкретный товар'
+
+  return (
+    <div style={{ width: '700px' }}>
+      <OverviewBox
+        title={title}
+        pageRoute={pageRoute}
+        pageRouteText={pageRouteText}
+        subtitle={subtitle}
+        itemRoute={itemRoute}
+        itemRouteText={itemRouteText}
+      />
+    </div>
+  )
+}
+
+Default.args = {
+  title: 'Заголовок карточки',
+  pageRoute: '#',
+  pageRouteText: 'Весь список',
+  subtitle: 'Вы ничего не покупали!',
+  itemRoute: '#',
+  itemRouteText: 'смотрим конкретный товар'
+}

--- a/src/entities/OverviewBox/ui/OverviewBox.tsx
+++ b/src/entities/OverviewBox/ui/OverviewBox.tsx
@@ -1,0 +1,52 @@
+import { FC } from 'react'
+
+import Heading, { HeadingType } from '@/shared/ui/Heading/Heading'
+import Link from '@/shared/ui/Link/Link'
+import Paragraph from '@/shared/ui/Paragraph/Paragraph'
+
+import styles from './OverviewBox.module.scss'
+
+interface IOverviewBox {
+  title: string
+  pageRoute: string
+  pageRouteText: string
+  subtitle?: string
+  itemRoute?: string
+  itemRouteText?: string
+}
+
+/**
+ * Компонент OverviewBox - это карточка которая используется в виджете OverviewBlock.
+ * @param {string} title - заголовок карточки
+ * @param {string} pageRoute - ссылка на общую страницу
+ * @param {string} pageRouteText - текст ссылки на общую страницу
+ * @param {string} subtitle - текст, если карточка пустая
+ * @param {string} itemRoute - ссылка на товар
+ * @param {string} itemRouteText - текст ссылки на товар
+ */
+
+const OverviewBox: FC<IOverviewBox> = ({
+  title,
+  pageRoute,
+  pageRouteText,
+  subtitle,
+  itemRoute,
+  itemRouteText
+}) => {
+  return (
+    <div className={styles.overviewBox}>
+      <div className={styles.overviewBox__title}>
+        <Heading type={HeadingType.NORMAL}>{title}</Heading>
+        <Link to={pageRoute} className={styles.overviewBox__pageRoute}>
+          {pageRouteText}
+        </Link>
+      </div>
+      <Paragraph className={styles.overviewBox__subtitle}>{subtitle}</Paragraph>
+      <Link to={itemRoute || '#'} className={styles.overviewBox__itemRouteText}>
+        {itemRouteText}
+      </Link>
+    </div>
+  )
+}
+
+export default OverviewBox

--- a/src/shared/config/routerConfig/routes.ts
+++ b/src/shared/config/routerConfig/routes.ts
@@ -22,5 +22,6 @@ export enum Routes {
   VOUCHERS = '/vouchers',
   PRODUCT = '/product',
   HELP = '/help',
-  REGISTRATION = '/registration'
+  REGISTRATION = '/registration',
+  ORDER_HISTORY = '/order-history'
 }

--- a/src/widgets/OverviewBlock/index.tsx
+++ b/src/widgets/OverviewBlock/index.tsx
@@ -1,0 +1,2 @@
+import OverviewBlock from './ui/OverviewBlock'
+export default OverviewBlock

--- a/src/widgets/OverviewBlock/ui/OverviewBlock.module.scss
+++ b/src/widgets/OverviewBlock/ui/OverviewBlock.module.scss
@@ -1,0 +1,5 @@
+.overviewBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}

--- a/src/widgets/OverviewBlock/ui/OverviewBlock.stories.tsx
+++ b/src/widgets/OverviewBlock/ui/OverviewBlock.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import OverviewBlock from './OverviewBlock'
+
+const meta = {
+  title: 'widgets/OverviewBlock',
+  component: OverviewBlock,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs']
+} satisfies Meta<typeof OverviewBlock>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = () => {
+  return (
+    <div style={{ width: '700px' }}>
+      <OverviewBlock />
+    </div>
+  )
+}
+
+Default.args = {}

--- a/src/widgets/OverviewBlock/ui/OverviewBlock.tsx
+++ b/src/widgets/OverviewBlock/ui/OverviewBlock.tsx
@@ -1,0 +1,41 @@
+import { FC } from 'react'
+
+import OverviewBox from '@/entities/OverviewBox'
+import { Routes } from '@/shared/config/routerConfig/routes'
+import Heading, { HeadingType } from '@/shared/ui/Heading/Heading'
+
+import styles from './OverviewBlock.module.scss'
+
+/**
+ * Компонент OverviewBlock - используется на странице личного кабинета.
+ */
+
+const OverviewBlock: FC = () => {
+  return (
+    <section className={styles.overviewBlock}>
+      <Heading type={HeadingType.MEDIUM}>Обзор</Heading>
+      <OverviewBox
+        title="Мой последний заказ"
+        pageRoute={Routes.ORDER_HISTORY}
+        pageRouteText="Все заказы"
+        subtitle="Вы еще не совершали покупок!"
+        // TODO - это пригодится когда буду прикручивать апи
+        // itemRoute={'#'}
+        // itemRouteText={'1 товар на общую сумму 768 ₽'}
+      />
+
+      <OverviewBox
+        title="Корзина"
+        pageRoute={Routes.CART}
+        pageRouteText="Вся корзина"
+        subtitle="Здесь будет карточка товара"
+        // TODO - это пригодится когда буду прикручивать апи
+        // subtitle="Ваша корзина пуста!"
+        itemRoute={'#'}
+        itemRouteText={'1 товар на общую сумму 768 ₽'}
+      />
+    </section>
+  )
+}
+
+export default OverviewBlock


### PR DESCRIPTION
- Блок "Обзор" используется на странице профиля, если пользователь авторизован.

- Блок OverviewBlock лежит в widgets, сторибук есть. Состоит из заголовка и двух однотипных карточек OverviewBox - лежит в entities, сторибук есть.

- Карточка имеет два состояния: пустая и полная. На картинках показано.
![4](https://github.com/Studio-Yandex-Practicum/maxboom_frontend/assets/109371389/a5e4af26-30b9-4aef-a1ee-ba82f5507786)
![3](https://github.com/Studio-Yandex-Practicum/maxboom_frontend/assets/109371389/9bb6ea10-7bdb-4d8f-bc77-20c43c5ff581)



- В сторибуке OverviewBlock, верхняя карточка пустая, нижняя с товаром. Это для примера